### PR TITLE
Add @FieldOrder annotation so Rule classes are minimized

### DIFF
--- a/Solana/src/main/java/com/solana/vendor/borshj/Borsh.kt
+++ b/Solana/src/main/java/com/solana/vendor/borshj/Borsh.kt
@@ -1,11 +1,7 @@
 package com.solana.vendor.borshj
 
-import com.solana.core.PublicKey
-import com.solana.core.PublicKeyRule
-import com.solana.models.Buffer.*
 import com.solana.vendor.borshj.BorshBuffer.Companion.allocate
 import com.solana.vendor.borshj.BorshBuffer.Companion.wrap
-import java.lang.Exception
 import java.util.*
 
 interface BorshCodable
@@ -13,16 +9,17 @@ interface BorshCodable
 interface BorshRule<T> {
     val clazz: Class<T>
     fun read(input: BorshInput): T?
-    fun <Self>write(obj: Any, output: BorshOutput<Self>): Self
+    fun <Self> write(obj: Any, output: BorshOutput<Self>): Self
 }
 
 class Borsh {
-    private var rules : List<BorshRule<*>> = listOf()
+    private var rules: List<BorshRule<*>> = listOf()
+
     fun setRules(rules: List<BorshRule<*>>) {
         this.rules = rules
     }
 
-    fun getRules() : List<BorshRule<*>> {
+    fun getRules(): List<BorshRule<*>> {
         return rules
     }
 

--- a/Solana/src/main/java/com/solana/vendor/borshj/Borsh.kt
+++ b/Solana/src/main/java/com/solana/vendor/borshj/Borsh.kt
@@ -24,9 +24,14 @@ class Borsh {
     }
 
     fun <T> isSerializable(klass: Class<T>?): Boolean {
-        return if (klass == null) false else Arrays.stream(klass.interfaces)
-            .anyMatch { iface: Class<*> -> iface == BorshCodable::class.java } ||
-                isSerializable(klass.superclass)
+        return if (klass == null) {
+            false
+        } else {
+            Arrays.stream(klass.interfaces)
+                .anyMatch {
+                        iface: Class<*> -> iface == BorshCodable::class.java
+                } || isSerializable(klass.superclass)
+        }
     }
 
     fun serialize(obj: Any): ByteArray {

--- a/Solana/src/main/java/com/solana/vendor/borshj/BorshInput.kt
+++ b/Solana/src/main/java/com/solana/vendor/borshj/BorshInput.kt
@@ -12,6 +12,7 @@ import kotlin.reflect.KClass
 interface BorshInput {
     fun <T> read(borsh: Borsh, klass: Class<*>): T {
         val rule = borsh.getRules().firstOrNull { it.clazz == klass }
+
         if (rule != null) {
             return rule.read(this) as T
         } else if (klass == Byte::class.java || klass == Byte::class.javaPrimitiveType || klass == Byte::class.javaObjectType) {
@@ -46,13 +47,15 @@ interface BorshInput {
             val kotlinParameters = constructor.parameters
 
             val declaredFields = klass.declaredFields
-                .filter { kotlinParameters.map{ kf -> kf.name }.contains(it.name) }
+                .filter { kotlinParameters.map { kf -> kf.name }.contains(it.name) }
+                .sortedBy { field -> field.getAnnotation(PropertyOrdinal::class.java).order }
 
             val map: MutableMap<String, Any?> = mutableMapOf()
             for (field in declaredFields) {
                 val kfield = kotlinParameters.first { it.name == field.name }
                 field.isAccessible = true
                 val fieldClass = field.type
+
                 if (kfield.isOptional) {
                     val fieldType = field.genericType as? ParameterizedType ?: throw AssertionError(
                         "unsupported Optional type"
@@ -70,6 +73,7 @@ interface BorshInput {
                 .parameters
                 .map { it to map.get(it.name) }
                 .toMap()
+
             constructor.callBy(args) as T
         } catch (error: NoSuchMethodException) {
             throw RuntimeException(error)
@@ -82,7 +86,7 @@ interface BorshInput {
         }
     }
 
-    fun <T : Any> mapToObject(map: Map<String, Any>, clazz: KClass<T>) : T {
+    fun <T : Any> mapToObject(map: Map<String, Any>, clazz: KClass<T>): T {
         //Get default constructor
         val constructor = clazz.constructors.first()
 

--- a/Solana/src/main/java/com/solana/vendor/borshj/BorshInput.kt
+++ b/Solana/src/main/java/com/solana/vendor/borshj/BorshInput.kt
@@ -48,18 +48,18 @@ interface BorshInput {
 
             val declaredFields = klass.declaredFields
                 .filter { kotlinParameters.map { kf -> kf.name }.contains(it.name) }
-                .sortedBy { field -> field.getAnnotation(PropertyOrdinal::class.java).order }
+                .sortedBy { field -> field.getAnnotation(FieldOrder::class.java).order }
 
             val map: MutableMap<String, Any?> = mutableMapOf()
             for (field in declaredFields) {
                 val kfield = kotlinParameters.first { it.name == field.name }
                 field.isAccessible = true
-                val fieldClass = field.type
 
                 if (kfield.isOptional) {
                     val fieldType = field.genericType as? ParameterizedType ?: throw AssertionError(
                         "unsupported Optional type"
                     )
+
                     val optionalArgs = fieldType.actualTypeArguments
                     assert(optionalArgs.size == 1)
                     val optionalClass = optionalArgs[0] as Class<*>

--- a/Solana/src/main/java/com/solana/vendor/borshj/BorshInput.kt
+++ b/Solana/src/main/java/com/solana/vendor/borshj/BorshInput.kt
@@ -46,6 +46,10 @@ interface BorshInput {
             val constructor = klass.kotlin.constructors.first()
             val kotlinParameters = constructor.parameters
 
+            if (klass.declaredFields.firstOrNull { !it.isAnnotationPresent(FieldOrder::class.java) } != null) {
+                throw java.lang.IllegalArgumentException("Deserializing borsh data requires all fields to be annotated with @FieldOrder")
+            }
+
             val declaredFields = klass.declaredFields
                 .filter { kotlinParameters.map { kf -> kf.name }.contains(it.name) }
                 .sortedBy { field -> field.getAnnotation(FieldOrder::class.java).order }

--- a/Solana/src/main/java/com/solana/vendor/borshj/BorshOutput.kt
+++ b/Solana/src/main/java/com/solana/vendor/borshj/BorshOutput.kt
@@ -35,6 +35,7 @@ interface BorshOutput<Self> {
 
             val fields = obj.javaClass.declaredFields
                 .filter { kotlinParameters.map { kf -> kf.name }.contains(it.name) }
+                .sortedBy { field -> field.getAnnotation(FieldOrder::class.java).order }
 
             for (field in fields) {
                 field.isAccessible = true

--- a/Solana/src/main/java/com/solana/vendor/borshj/BorshOutput.kt
+++ b/Solana/src/main/java/com/solana/vendor/borshj/BorshOutput.kt
@@ -33,6 +33,10 @@ interface BorshOutput<Self> {
             val constructor = obj.javaClass.kotlin.constructors.first()
             val kotlinParameters = constructor.parameters
 
+            if (obj.javaClass.declaredFields.firstOrNull { !it.isAnnotationPresent(FieldOrder::class.java) } != null) {
+                throw java.lang.IllegalArgumentException("Serializing borsh data requires all fields to be annotated with @FieldOrder")
+            }
+
             val fields = obj.javaClass.declaredFields
                 .filter { kotlinParameters.map { kf -> kf.name }.contains(it.name) }
                 .sortedBy { field -> field.getAnnotation(FieldOrder::class.java).order }

--- a/Solana/src/main/java/com/solana/vendor/borshj/BorshOutput.kt
+++ b/Solana/src/main/java/com/solana/vendor/borshj/BorshOutput.kt
@@ -1,8 +1,6 @@
 package com.solana.vendor.borshj
 
-import com.solana.core.PublicKey
 import com.solana.vendor.borshj.BorshBuffer.Companion.allocate
-import java.lang.reflect.Modifier
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 import java.util.*
@@ -10,6 +8,7 @@ import java.util.*
 interface BorshOutput<Self> {
     fun write(borsh: Borsh, obj: Any): Self {
         val rule: BorshRule<*>? = borsh.getRules().firstOrNull { it.clazz == obj.javaClass }
+
         return when {
             rule != null -> rule.write(obj, this)
             obj is Byte -> writeU8(obj)
@@ -44,6 +43,7 @@ interface BorshOutput<Self> {
         } catch (error: IllegalAccessException) {
             throw RuntimeException(error)
         }
+
         return this as Self
     }
 

--- a/Solana/src/main/java/com/solana/vendor/borshj/FieldOrder.kt
+++ b/Solana/src/main/java/com/solana/vendor/borshj/FieldOrder.kt
@@ -2,6 +2,6 @@ package com.solana.vendor.borshj
 
 @Target(AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class PropertyOrdinal(
+annotation class FieldOrder(
     val order: Int
 )

--- a/Solana/src/main/java/com/solana/vendor/borshj/PropertyOrdinal.kt
+++ b/Solana/src/main/java/com/solana/vendor/borshj/PropertyOrdinal.kt
@@ -1,0 +1,7 @@
+package com.solana.vendor.borshj
+
+@Target(AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PropertyOrdinal(
+    val order: Int
+)

--- a/Solana/src/test/java/com/solana/models/DecodingTest.kt
+++ b/Solana/src/test/java/com/solana/models/DecodingTest.kt
@@ -24,10 +24,35 @@ class DecodingTests {
         val byteArray = Base64.getDecoder().decode(blobSrc)
 
         val data = borsh.deserialize(byteArray, MetaplexMeta::class.java)
-        assertEquals(data, data)
+        assertEquals("5Fc7Zy7HgRatL8XhX5uqsUFEjGPop1uJXKrp3Ws7m1Tn", data.update_authority.toBase58())
+        assertEquals("26r3GfgqbjMTjZahNgnwa9AtbDg8x2E5AGwzw17KWRC4", data.mint.toBase58())
+        assertEquals("Solanimal #1962 - Cat", data.data.name)
+        assertEquals("https://arweave.net/4DVSaR56WTkWV8Nyoge4-tPX-p9raIBRpyY4KqeVeP4", data.data.uri)
     }
 
-//    @Test
+    @Test
+    fun testMoreDecodingMetaplexMeta() {
+        val borsh = borsh()
+
+        val plexData = MetaplexData("NFT", "BORSH", "www.solana.com")
+        val plexMeta = MetaplexMeta(
+            key = 1,
+            update_authority = PublicKey("CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3"),
+            mint = PublicKey("BQWWFhzBdw2vKKBUX17NHeFbCoFQHfRARpdztPE2tDJ"),
+            data = plexData
+        )
+
+        val serialized = borsh.serialize(plexMeta)
+        val out = borsh.deserialize(serialized, MetaplexMeta::class.java)
+
+        assertEquals("CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3", out.update_authority.toBase58())
+        assertEquals("BQWWFhzBdw2vKKBUX17NHeFbCoFQHfRARpdztPE2tDJ", out.mint.toBase58())
+        assertEquals("NFT", out.data.name)
+        assertEquals("BORSH", out.data.symbol)
+        assertEquals("www.solana.com", out.data.uri)
+    }
+
+    @Test
     fun testDecodingPublicKey() {
         val borsh = borsh()
         val bytes = byteArrayOf( 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
@@ -40,7 +65,7 @@ class DecodingTests {
     }
 
 
-//    @Test
+    @Test
     fun testDecodingMint() {
         val borsh = borsh()
         val rawData = listOf(
@@ -69,7 +94,7 @@ class DecodingTests {
         assertEquals(deserialized.freezeAuthority, mintLayout.freezeAuthority)
     }
 
-//    @Test
+    @Test
     fun testDecodingAccountInfo() {
         val borsh = borsh()
         val rawData: List<String> = listOf(
@@ -111,7 +136,7 @@ class DecodingTests {
         assertEquals(deserialized.closeAuthority, accountInfo.closeAuthority)
     }
 
-//    @Test
+    @Test
     fun testDecodingAccountInfo2() {
         val borsh = borsh()
         val string = listOf(
@@ -143,7 +168,7 @@ class DecodingTests {
         assertEquals(true, accountInfo2.isFrozen)
     }
 
-//    @Test
+    @Test
     fun testDecodingTokenSwap() {
         val borsh = borsh()
         val string = listOf(

--- a/Solana/src/test/java/com/solana/models/DecodingTest.kt
+++ b/Solana/src/test/java/com/solana/models/DecodingTest.kt
@@ -12,7 +12,7 @@ class DecodingTests {
 
     fun borsh(): Borsh {
         val borsh = Borsh()
-        borsh.setRules(listOf(PublicKeyRule(), AccountInfoRule(), MintRule(), TokenSwapInfoRule(), MetaplexDataRule(), MetaplexMetaRule()))
+        borsh.setRules(listOf(PublicKeyRule(), AccountInfoRule(), MintRule(), TokenSwapInfoRule()))
         return borsh
     }
 
@@ -27,7 +27,7 @@ class DecodingTests {
         assertEquals(data, data)
     }
 
-    @Test
+//    @Test
     fun testDecodingPublicKey() {
         val borsh = borsh()
         val bytes = byteArrayOf( 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
@@ -40,7 +40,7 @@ class DecodingTests {
     }
 
 
-    @Test
+//    @Test
     fun testDecodingMint() {
         val borsh = borsh()
         val rawData = listOf(
@@ -69,7 +69,7 @@ class DecodingTests {
         assertEquals(deserialized.freezeAuthority, mintLayout.freezeAuthority)
     }
 
-    @Test
+//    @Test
     fun testDecodingAccountInfo() {
         val borsh = borsh()
         val rawData: List<String> = listOf(
@@ -111,7 +111,7 @@ class DecodingTests {
         assertEquals(deserialized.closeAuthority, accountInfo.closeAuthority)
     }
 
-    @Test
+//    @Test
     fun testDecodingAccountInfo2() {
         val borsh = borsh()
         val string = listOf(
@@ -143,7 +143,7 @@ class DecodingTests {
         assertEquals(true, accountInfo2.isFrozen)
     }
 
-    @Test
+//    @Test
     fun testDecodingTokenSwap() {
         val borsh = borsh()
         val string = listOf(

--- a/Solana/src/test/java/com/solana/models/DecodingTest.kt
+++ b/Solana/src/test/java/com/solana/models/DecodingTest.kt
@@ -4,15 +4,27 @@ import com.solana.core.PublicKey
 import com.solana.core.PublicKeyRule
 import com.solana.models.Buffer.*
 import com.solana.vendor.borshj.Borsh
-import org.junit.Test
 import org.junit.Assert.*
+import org.junit.Test
+import java.util.*
 
 class DecodingTests {
 
     fun borsh(): Borsh {
         val borsh = Borsh()
-        borsh.setRules(listOf(PublicKeyRule(), AccountInfoRule(), MintRule(), TokenSwapInfoRule()))
+        borsh.setRules(listOf(PublicKeyRule(), AccountInfoRule(), MintRule(), TokenSwapInfoRule(), MetaplexDataRule(), MetaplexMetaRule()))
         return borsh
+    }
+
+    @Test
+    fun testDecodingMetaplexMeta() {
+        val blobSrc = "BD8slOrgPZpL+5iD8MJBsTGY+esK0dZd8tlCX14LRmfREFsKKgyOBm9TbEDjhj2CcT+KPJFJ3acbYRLIqSsfsUkVAAAAU29sYW5pbWFsICMxOTYyIC0gQ2F0AAAAAD8AAABodHRwczovL2Fyd2VhdmUubmV0LzREVlNhUjU2V1RrV1Y4TnlvZ2U0LXRQWC1wOXJhSUJScHlZNEtxZVZlUDQAAAEBAAAAPyyU6uA9mkv7mIPwwkGxMZj56wrR1l3y2UJfXgtGZ9EBZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+
+        val borsh = borsh()
+        val byteArray = Base64.getDecoder().decode(blobSrc)
+
+        val data = borsh.deserialize(byteArray, MetaplexMeta::class.java)
+        assertEquals(data, data)
     }
 
     @Test

--- a/Solana/src/test/java/com/solana/models/MetaplexInfra.kt
+++ b/Solana/src/test/java/com/solana/models/MetaplexInfra.kt
@@ -1,62 +1,18 @@
 package com.solana.models
 
 import com.solana.core.PublicKey
-import com.solana.core.PublicKeyRule
 import com.solana.vendor.borshj.BorshCodable
-import com.solana.vendor.borshj.BorshInput
-import com.solana.vendor.borshj.BorshOutput
-import com.solana.vendor.borshj.BorshRule
+import com.solana.vendor.borshj.PropertyOrdinal
 
 data class MetaplexMeta(
-    val key: Byte,
-    val update_authority: PublicKey,
-    val mint: PublicKey,
-    val data: MetaplexData
+    @PropertyOrdinal(order = 0) val key: Byte,
+    @PropertyOrdinal(order = 1) val update_authority: PublicKey,
+    @PropertyOrdinal(order = 2) val mint: PublicKey,
+    @PropertyOrdinal(order = 3) val data: MetaplexData
 ): BorshCodable
-
-class MetaplexMetaRule(
-    override val clazz: Class<MetaplexMeta> = MetaplexMeta::class.java
-): BorshRule<MetaplexMeta> {
-
-    override fun read(input: BorshInput): MetaplexMeta {
-        return MetaplexMeta(
-            input.readU8(),
-            PublicKeyRule().read(input),
-            PublicKeyRule().read(input),
-            MetaplexDataRule().read(input)
-        )
-    }
-
-    override fun <Self> write(obj: Any, output: BorshOutput<Self>): Self {
-        TODO("Not yet implemented")
-    }
-
-}
 
 data class MetaplexData(
-    val name: String,
-    val symbol: String,
-    val uri: String
+    @PropertyOrdinal(order = 0) val name: String,
+    @PropertyOrdinal(order = 0) val symbol: String,
+    @PropertyOrdinal(order = 0) val uri: String
 ): BorshCodable
-
-class MetaplexDataRule(
-    override val clazz: Class<MetaplexData> = MetaplexData::class.java
-): BorshRule<MetaplexData> {
-
-    override fun read(input: BorshInput): MetaplexData {
-        val name = input.readString()
-        val symbol = input.readString()
-        val uri = input.readString()
-
-        return MetaplexData(
-            name,
-            symbol,
-            uri
-        )
-    }
-
-    override fun <Self> write(obj: Any, output: BorshOutput<Self>): Self {
-        TODO("Not yet implemented")
-    }
-
-}

--- a/Solana/src/test/java/com/solana/models/MetaplexInfra.kt
+++ b/Solana/src/test/java/com/solana/models/MetaplexInfra.kt
@@ -1,0 +1,62 @@
+package com.solana.models
+
+import com.solana.core.PublicKey
+import com.solana.core.PublicKeyRule
+import com.solana.vendor.borshj.BorshCodable
+import com.solana.vendor.borshj.BorshInput
+import com.solana.vendor.borshj.BorshOutput
+import com.solana.vendor.borshj.BorshRule
+
+data class MetaplexMeta(
+    val key: Byte,
+    val update_authority: PublicKey,
+    val mint: PublicKey,
+    val data: MetaplexData
+): BorshCodable
+
+class MetaplexMetaRule(
+    override val clazz: Class<MetaplexMeta> = MetaplexMeta::class.java
+): BorshRule<MetaplexMeta> {
+
+    override fun read(input: BorshInput): MetaplexMeta {
+        return MetaplexMeta(
+            input.readU8(),
+            PublicKeyRule().read(input),
+            PublicKeyRule().read(input),
+            MetaplexDataRule().read(input)
+        )
+    }
+
+    override fun <Self> write(obj: Any, output: BorshOutput<Self>): Self {
+        TODO("Not yet implemented")
+    }
+
+}
+
+data class MetaplexData(
+    val name: String,
+    val symbol: String,
+    val uri: String
+): BorshCodable
+
+class MetaplexDataRule(
+    override val clazz: Class<MetaplexData> = MetaplexData::class.java
+): BorshRule<MetaplexData> {
+
+    override fun read(input: BorshInput): MetaplexData {
+        val name = input.readString()
+        val symbol = input.readString()
+        val uri = input.readString()
+
+        return MetaplexData(
+            name,
+            symbol,
+            uri
+        )
+    }
+
+    override fun <Self> write(obj: Any, output: BorshOutput<Self>): Self {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/Solana/src/test/java/com/solana/models/MetaplexInfra.kt
+++ b/Solana/src/test/java/com/solana/models/MetaplexInfra.kt
@@ -2,17 +2,17 @@ package com.solana.models
 
 import com.solana.core.PublicKey
 import com.solana.vendor.borshj.BorshCodable
-import com.solana.vendor.borshj.PropertyOrdinal
+import com.solana.vendor.borshj.FieldOrder
 
 data class MetaplexMeta(
-    @PropertyOrdinal(order = 0) val key: Byte,
-    @PropertyOrdinal(order = 1) val update_authority: PublicKey,
-    @PropertyOrdinal(order = 2) val mint: PublicKey,
-    @PropertyOrdinal(order = 3) val data: MetaplexData
+    @FieldOrder(0) val key: Byte,
+    @FieldOrder(1) val update_authority: PublicKey,
+    @FieldOrder(2) val mint: PublicKey,
+    @FieldOrder(3) val data: MetaplexData
 ): BorshCodable
 
 data class MetaplexData(
-    @PropertyOrdinal(order = 0) val name: String,
-    @PropertyOrdinal(order = 0) val symbol: String,
-    @PropertyOrdinal(order = 0) val uri: String
+    @FieldOrder(0) val name: String,
+    @FieldOrder(1) val symbol: String,
+    @FieldOrder(2) val uri: String
 ): BorshCodable

--- a/Solana/src/test/java/com/solana/vendor/borsh/BorshTests.kt
+++ b/Solana/src/test/java/com/solana/vendor/borsh/BorshTests.kt
@@ -1,11 +1,8 @@
 package com.solana.vendor.borsh
 
-import com.solana.core.PublicKeyRule
-import com.solana.models.Buffer.AccountInfoRule
-import com.solana.models.Buffer.MintRule
-import com.solana.models.Buffer.TokenSwapInfoRule
 import com.solana.vendor.borshj.Borsh
 import com.solana.vendor.borshj.BorshCodable
+import com.solana.vendor.borshj.FieldOrder
 import org.junit.Assert
 import org.junit.Test
 
@@ -26,7 +23,9 @@ class BorshTests {
     }
 
     class Point2Df : BorshCodable {
+        @FieldOrder(0)
         private var x = 0f
+        @FieldOrder(1)
         private var y = 0f
 
         constructor(x: Float, y: Float) {
@@ -46,7 +45,9 @@ class BorshTests {
     }
 
     class Rect2Df : BorshCodable {
+        @FieldOrder(0)
         private var topLeft: Point2Df? = null
+        @FieldOrder(1)
         private var bottomRight: Point2Df? = null
 
         constructor(topLeft: Point2Df?, bottomRight: Point2Df?) {


### PR DESCRIPTION
When digging through the Borsh operation, it became clear that for serializing/deserializing the fields need to be encountered in the same order so the bytes can be read/written properly. Your most recent Rule system really helped formalize making that happen, but I realized that for many field types if we could just specify the order, that would be enough.

Hence this PR - now you can just annotate the fields with ```@FieldOrder()``` and for many classes, no Rule class will be necessary. The rule system still works great for special cases, but hopefully this should reduce the boilerplate needed for most classes. Even the PublicKeyRule could likely be simplified/removed as a result of this annotation, though I didn't do that work for this PR.