### PR TITLE
Use min sdk 16

### DIFF
--- a/solana/build.gradle
+++ b/solana/build.gradle
@@ -12,7 +12,7 @@ android {
     buildToolsVersion '30.0.2'
 
     defaultConfig {
-        minSdkVersion 27
+        minSdkVersion 16
         targetSdkVersion 30
         versionCode 1
         versionName "1.1.0"


### PR DESCRIPTION
With the current changes we can now reduce the required sdk up to 16. Fixes #79