### PR TITLE
Add ability to setFeePayer, add toString methods

### DIFF
--- a/solana/src/main/java/com/solana/core/AccountMeta.kt
+++ b/solana/src/main/java/com/solana/core/AccountMeta.kt
@@ -1,3 +1,7 @@
 package com.solana.core
 
-class AccountMeta(var publicKey: PublicKey, var isSigner: Boolean, var isWritable: Boolean)
+class AccountMeta(var publicKey: PublicKey, var isSigner: Boolean, var isWritable: Boolean) {
+    override fun toString(): String {
+        return "AccountMeta(publicKey: $publicKey, isSigner: $isSigner, isWritable: $isWritable)"
+    }
+}

--- a/solana/src/main/java/com/solana/core/Message.kt
+++ b/solana/src/main/java/com/solana/core/Message.kt
@@ -39,7 +39,7 @@ class Message {
     private var recentBlockhash: String? = null
     private val accountKeys: AccountKeysList = AccountKeysList()
     private val instructions: MutableList<TransactionInstruction>
-    private var feePayer: Account? = null
+    private var feePayer: PublicKey? = null
     fun addInstruction(instruction: TransactionInstruction): Message {
         accountKeys.addAll(instruction.keys)
         accountKeys.add(AccountMeta(instruction.programId, false, false))
@@ -111,13 +111,13 @@ class Message {
         return out.array()
     }
 
-    fun setFeePayer(feePayer: Account?) {
+    fun setFeePayer(feePayer: PublicKey?) {
         this.feePayer = feePayer
     }
 
     private fun getAccountKeys(): List<AccountMeta> {
         val keysList: MutableList<AccountMeta> = accountKeys.list
-        val feePayerIndex = findAccountIndex(keysList, feePayer!!.publicKey)
+        val feePayerIndex = findAccountIndex(keysList, feePayer!!)
         val newList: MutableList<AccountMeta> = ArrayList()
         val feePayerMeta = keysList[feePayerIndex]
         newList.add(AccountMeta(feePayerMeta.publicKey, true, true))

--- a/solana/src/main/java/com/solana/core/Message.kt
+++ b/solana/src/main/java/com/solana/core/Message.kt
@@ -39,7 +39,8 @@ class Message {
     private var recentBlockhash: String? = null
     private val accountKeys: AccountKeysList = AccountKeysList()
     private val instructions: MutableList<TransactionInstruction>
-    private var feePayer: PublicKey? = null
+    var feePayer: PublicKey? = null
+
     fun addInstruction(instruction: TransactionInstruction): Message {
         accountKeys.addAll(instruction.keys)
         accountKeys.add(AccountMeta(instruction.programId, false, false))
@@ -109,10 +110,6 @@ class Message {
             out.put(compiledInstruction.data)
         }
         return out.array()
-    }
-
-    fun setFeePayer(feePayer: PublicKey?) {
-        this.feePayer = feePayer
     }
 
     private fun getAccountKeys(): List<AccountMeta> {

--- a/solana/src/main/java/com/solana/core/Message.kt
+++ b/solana/src/main/java/com/solana/core/Message.kt
@@ -18,6 +18,10 @@ class Message {
             )
         }
 
+        override fun toString(): String {
+            return "numRequiredSignatures: $numRequiredSignatures, numReadOnlySignedAccounts: $numReadonlySignedAccounts, numReadOnlyUnsignedAccounts: $numReadonlyUnsignedAccounts"
+        }
+
         companion object {
             const val HEADER_LENGTH = 3
         }
@@ -130,6 +134,15 @@ class Message {
             }
         }
         throw RuntimeException("unable to find account index")
+    }
+
+    override fun toString(): String {
+        return """Message(
+            | header: not set,
+            | accountKeys: [${accountKeys.list.joinToString()}],
+            | recentBlockhash: $recentBlockhash,
+            | instructions: [${instructions.joinToString()}]
+        )""".trimMargin()
     }
 
     companion object {

--- a/solana/src/main/java/com/solana/core/Message.kt
+++ b/solana/src/main/java/com/solana/core/Message.kt
@@ -118,11 +118,15 @@ class Message {
 
     private fun getAccountKeys(): List<AccountMeta> {
         val keysList: MutableList<AccountMeta> = accountKeys.list
-        val feePayerIndex = findAccountIndex(keysList, feePayer!!)
         val newList: MutableList<AccountMeta> = ArrayList()
-        val feePayerMeta = keysList[feePayerIndex]
-        newList.add(AccountMeta(feePayerMeta.publicKey, true, true))
-        keysList.removeAt(feePayerIndex)
+        try {
+            val feePayerIndex = findAccountIndex(keysList, feePayer!!)
+            val feePayerMeta = keysList[feePayerIndex]
+            newList.add(AccountMeta(feePayerMeta.publicKey, true, true))
+            keysList.removeAt(feePayerIndex)
+        } catch(e: RuntimeException) { // Fee payer not yet in list
+            newList.add(AccountMeta(feePayer!!, true, true))
+        }
         newList.addAll(keysList)
         return newList
     }
@@ -138,11 +142,11 @@ class Message {
 
     override fun toString(): String {
         return """Message(
-            | header: not set,
-            | accountKeys: [${accountKeys.list.joinToString()}],
-            | recentBlockhash: $recentBlockhash,
-            | instructions: [${instructions.joinToString()}]
-        )""".trimMargin()
+            |  header: not set,
+            |  accountKeys: [${accountKeys.list.joinToString()}],
+            |  recentBlockhash: $recentBlockhash,
+            |  instructions: [${instructions.joinToString()}]
+        |)""".trimMargin()
     }
 
     companion object {

--- a/solana/src/main/java/com/solana/core/Transaction.kt
+++ b/solana/src/main/java/com/solana/core/Transaction.kt
@@ -19,7 +19,7 @@ class Transaction {
         message.setRecentBlockHash(recentBlockhash)
     }
 
-    fun setFeePayer(feePayer: Account?) {
+    fun setFeePayer(feePayer: PublicKey?) {
         message.setFeePayer(feePayer)
     }
 
@@ -29,7 +29,7 @@ class Transaction {
 
     fun sign(signers: List<Account>) {
         require(signers.size != 0) { "No signers" }
-        val feePayer = signers[0]
+        val feePayer = signers[0].publicKey
         message.setFeePayer(feePayer)
         serializedMessage = message.serialize()
         for (signer in signers) {

--- a/solana/src/main/java/com/solana/core/Transaction.kt
+++ b/solana/src/main/java/com/solana/core/Transaction.kt
@@ -19,6 +19,10 @@ class Transaction {
         message.setRecentBlockHash(recentBlockhash)
     }
 
+    fun setFeePayer(feePayer: Account?) {
+        message.setFeePayer(feePayer)
+    }
+
     fun sign(signer: Account) {
         sign(listOf(signer))
     }

--- a/solana/src/main/java/com/solana/core/Transaction.kt
+++ b/solana/src/main/java/com/solana/core/Transaction.kt
@@ -57,9 +57,9 @@ class Transaction {
 
     override fun toString(): String {
         return """Transaction(
-            | signatures: [${signatures.joinToString()}],
-            | message: ${message}
-        )""".trimMargin()
+            |  signatures: [${signatures.joinToString()}],
+            |  message: ${message}
+        |)""".trimMargin()
     }
 
     companion object {

--- a/solana/src/main/java/com/solana/core/Transaction.kt
+++ b/solana/src/main/java/com/solana/core/Transaction.kt
@@ -55,6 +55,13 @@ class Transaction {
         return out.array()
     }
 
+    override fun toString(): String {
+        return """Transaction(
+            | signatures: [${signatures.joinToString()}],
+            | message: ${message}
+        )""".trimMargin()
+    }
+
     companion object {
         const val SIGNATURE_LENGTH = 64
     }

--- a/solana/src/main/java/com/solana/core/Transaction.kt
+++ b/solana/src/main/java/com/solana/core/Transaction.kt
@@ -20,7 +20,7 @@ class Transaction {
     }
 
     fun setFeePayer(feePayer: PublicKey?) {
-        message.setFeePayer(feePayer)
+        message.feePayer = feePayer
     }
 
     fun sign(signer: Account) {
@@ -29,8 +29,10 @@ class Transaction {
 
     fun sign(signers: List<Account>) {
         require(signers.size != 0) { "No signers" }
-        val feePayer = signers[0].publicKey
-        message.setFeePayer(feePayer)
+        // Fee payer defaults to first signer if not set
+        message.feePayer ?: let {
+            message.feePayer = signers[0].publicKey
+        }
         serializedMessage = message.serialize()
         for (signer in signers) {
             val signatureProvider = TweetNaclFast.Signature(ByteArray(0), signer.secretKey)

--- a/solana/src/main/java/com/solana/core/TransactionInstruction.kt
+++ b/solana/src/main/java/com/solana/core/TransactionInstruction.kt
@@ -4,4 +4,12 @@ class TransactionInstruction(
     var programId: PublicKey,
     var keys: List<AccountMeta>,
     var data: ByteArray
-)
+) {
+    override fun toString(): String {
+        return """TransactionInstruction(
+            |  programId: $programId,
+            |  keys: [${keys.joinToString()}],
+            |  data: [${data.joinToString()}]
+        |)""".trimMargin()
+    }
+}

--- a/solana/src/test/java/com/solana/core/MessageTest.java
+++ b/solana/src/test/java/com/solana/core/MessageTest.java
@@ -21,7 +21,7 @@ public class MessageTest {
         Message message = new Message();
         message.addInstruction(SystemProgram.transfer(fromPublicKey, toPublickKey, lamports));
         message.setRecentBlockHash("Eit7RCyhUixAe2hGBS8oqnw59QK3kgMMjfLME5bm9wRn");
-        message.setFeePayer(signer);
+        message.setFeePayer(signer.getPublicKey());
 
         assertArrayEquals(new int[] { 1, 0, 1, 3, 6, 26, 217, 208, 83, 135, 21, 72, 83, 126, 222, 62, 38, 24, 73, 163,
                 223, 183, 253, 2, 250, 188, 117, 178, 35, 200, 228, 106, 219, 133, 61, 12, 235, 122, 188, 208, 216, 117,


### PR DESCRIPTION
Currently Message.setFeePayer is not exposed to the Transaction. It's only used to automatically set the first signature in the list to FeePayer. Acording to the Solana spec, this is a good default but it should be configurable. This PR adds the ability to specify a fee payer. See below in-line github comments for places it may need to be written differently.

I also added toString methods to all the Transaction components because they made my debugging easier.