### PR TITLE
Implement initializeMint instruction

### DIFF
--- a/solana/src/test/java/com/solana/actions/TokenProgramTest.kt
+++ b/solana/src/test/java/com/solana/actions/TokenProgramTest.kt
@@ -1,0 +1,77 @@
+package com.solana.actions
+
+
+import com.solana.core.Account
+import com.solana.core.PublicKey
+import com.solana.core.Transaction
+import com.solana.programs.TokenProgram
+import junit.framework.Assert.assertEquals
+import org.junit.Test
+import java.util.*
+
+
+class TokenProgramTest {
+    @Test
+    fun initializeMint() {
+        val instruction = TokenProgram.initializeMint(MINT_ACCOUNT_SIGNER.publicKey, 0, MINT_AUTHORITY);
+
+        val serializedTransaction = with(Transaction()) {
+            addInstruction(instruction)
+            setRecentBlockHash("Eit7RCyhUixAe2hGBS8oqnw59QK3kgMMjfLME5bm9wRn")
+            sign(MINT_ACCOUNT_SIGNER)
+            serialize()
+        }
+
+        assertEquals(
+            "AUoR2pOLvCw+4HBuJeRwiFZrQEUwxGxjwYL7lt7Ml7+gnqJ5GDKXPZzqc86enRU/eWrbrTwjTqnwtvCzTorbyQwBAAIDdzBsVYjcOAdulE3ZeRcnn0fqEGjydBJqwCb++mjnoPAGp9UXGSxcUSGMyUw9SvF/WNruCJuh/UTj29mKAAAAAAbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCpy+KIwZmU8DLmYglP3bPzrlpDaKkGu6VIJJwTOYQmRfUBAgIAAUMAAHliGrHMD2/tnxlfFt004e78Gx01J8/pMuF7TJD14g6yAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            Base64.getEncoder().encodeToString(serializedTransaction)
+        )
+    }
+
+    @Test
+    fun initializeMint_withFreezeAuthority() {
+        val instruction = TokenProgram.initializeMint(MINT_ACCOUNT_SIGNER.publicKey, 0, MINT_AUTHORITY, FREEZE_AUTHORITY);
+
+        val serializedTransaction = with(Transaction()) {
+            addInstruction(instruction)
+            setRecentBlockHash("Eit7RCyhUixAe2hGBS8oqnw59QK3kgMMjfLME5bm9wRn")
+            sign(MINT_ACCOUNT_SIGNER)
+            serialize()
+        }
+
+        assertEquals(
+            "Aa/cfiQCH2/Q1hGyG9bZYvmcMvJH+Y0IzAnA1GuhnqlzRUFzRpR261HQaUYXvW0VNPA8pvqrOIHtK0Ks4kemSQoBAAIDdzBsVYjcOAdulE3ZeRcnn0fqEGjydBJqwCb++mjnoPAGp9UXGSxcUSGMyUw9SvF/WNruCJuh/UTj29mKAAAAAAbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCpy+KIwZmU8DLmYglP3bPzrlpDaKkGu6VIJJwTOYQmRfUBAgIAAUMAAHliGrHMD2/tnxlfFt004e78Gx01J8/pMuF7TJD14g6yAQ8o+2LHwHas60HhK0I2UCPRN1mzPCOeLzEIW4SoYdJ9",
+            Base64.getEncoder().encodeToString(serializedTransaction)
+        )
+    }
+
+    @Test
+    fun initializeMint_withFreezeAuthorityAnd9Decimals() {
+        val instruction = TokenProgram.initializeMint(MINT_ACCOUNT_SIGNER.publicKey, 9, MINT_AUTHORITY, FREEZE_AUTHORITY);
+
+        val serializedTransaction = with(Transaction()) {
+            addInstruction(instruction)
+            setRecentBlockHash("Eit7RCyhUixAe2hGBS8oqnw59QK3kgMMjfLME5bm9wRn")
+            sign(MINT_ACCOUNT_SIGNER)
+            serialize()
+        }
+
+        assertEquals(
+            "ATZzZcv9ZRHTIoqeRP79u4kX9HdkluOCICsV001wKCNAZhAIKc6jqXNDJVTxoLIVRq5Dltt/bdfW1H7DJ94rOAMBAAIDdzBsVYjcOAdulE3ZeRcnn0fqEGjydBJqwCb++mjnoPAGp9UXGSxcUSGMyUw9SvF/WNruCJuh/UTj29mKAAAAAAbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCpy+KIwZmU8DLmYglP3bPzrlpDaKkGu6VIJJwTOYQmRfUBAgIAAUMACXliGrHMD2/tnxlfFt004e78Gx01J8/pMuF7TJD14g6yAQ8o+2LHwHas60HhK0I2UCPRN1mzPCOeLzEIW4SoYdJ9",
+            Base64.getEncoder().encodeToString(serializedTransaction)
+        )
+    }
+
+    companion object {
+        // public key: 92GLpcVjbC1dA4TNRrb6ooNQGj7iqYk4bR1Xvwat2Wkf
+        private val MINT_SECRET_KEY = intArrayOf(248, 245, 206, 215, 221, 248, 207, 125, 63, 204, 25, 40, 10, 180, 174,
+            189, 124, 221, 111, 20, 34, 34, 147, 0, 194, 55, 115, 203, 41, 9, 128,
+            188, 119, 48, 108, 85, 136, 220, 56, 7, 110, 148, 77, 217, 121, 23, 39,
+            159, 71, 234, 16, 104, 242, 116, 18, 106, 192, 38, 254, 250, 104, 231,
+            160, 240).map(Int::toByte).toByteArray()
+        private val MINT_ACCOUNT_SIGNER = Account(MINT_SECRET_KEY)
+
+        private val MINT_AUTHORITY = PublicKey("9Aq6XkUT8Nx2ztkpkUxc4HiVCFWKTJZWiLnhC94iofvy")
+        private val FREEZE_AUTHORITY = PublicKey("22BMtVRGveoYeJyvYDHfJP5JMCRKTYbp3QMhxU1P8w1n")
+    }
+}


### PR DESCRIPTION
# Description

Adds initializeMint instruction + some unit tests to ensure it's working as a low-level instruction. Note that I haven't tested it outside of serializing it in a transaction.

For some reference, I'm currently trying to support the equivalent of [`createNFT.ts`](https://github.com/metaplex-foundation/js/blob/main/packages/js/src/plugins/nftModule/createNft.ts) in [`metaplex-android`](https://github.com/metaplex-foundation/metaplex-android) as I haven't seen it implemented.

This is part 1 of 2 new instructions I want to add to SolanaKT, the other being [`mintTo`](https://github.com/solana-labs/solana-program-library/blob/f487f520bf10ca29bf8d491192b6ff2b4bf89710/token/js/src/instructions/mintTo.ts).

### Implementation references

I translated [`initializeMint.ts`](https://github.com/solana-labs/solana-program-library/blob/f487f520bf10ca29bf8d491192b6ff2b4bf89710/token/js/src/instructions/initializeMint.ts), using the [`initializeAccount.ts`](https://github.com/solana-labs/solana-program-library/blob/f487f520bf10ca29bf8d491192b6ff2b4bf89710/token/js/src/instructions/initializeAccount.ts) TS and Android (this lib) implementations as references.

Then I ran some local TS code to get some serialized Transaction values.

### Serialized Transaction Values

Expected serialized transaction values come from some reference TS code. I just used the latest code from https://github.com/metaplex-foundation/js/ to generate them.

```typescript
import { initializeMintBuilder } from "@metaplex-foundation/js";
import { Keypair, PublicKey } from "@solana/web3.js";

const mintKeypair = Keypair.fromSecretKey(
  new Uint8Array([
    248, 245, 206, 215, 221, 248, 207, 125, 63, 204, 25, 40, 10, 180, 174,
    189, 124, 221, 111, 20, 34, 34, 147, 0, 194, 55, 115, 203, 41, 9, 128,
    188, 119, 48, 108, 85, 136, 220, 56, 7, 110, 148, 77, 217, 121, 23, 39,
    159, 71, 234, 16, 104, 242, 116, 18, 106, 192, 38, 254, 250, 104, 231,
    160, 240,
  ])
);
const mintAuthority = new PublicKey(
  "9Aq6XkUT8Nx2ztkpkUxc4HiVCFWKTJZWiLnhC94iofvy"
);
const freezeAuthority = new PublicKey(
  "22BMtVRGveoYeJyvYDHfJP5JMCRKTYbp3QMhxU1P8w1n"
);
console.log("mint public key:", mintKeypair.publicKey.toBase58());
console.log("mint secret key:", mintKeypair.secretKey.toString());
console.log("mint authority public key:", mintAuthority.toBase58());
console.log("freeze authority public key:", freezeAuthority.toBase58());
const tx = initializeMintBuilder({
  mint: mintKeypair,
  decimals: 9,
  mintAuthority,
  freezeAuthority,
}).toTransaction();

tx.recentBlockhash = "Eit7RCyhUixAe2hGBS8oqnw59QK3kgMMjfLME5bm9wRn";
tx.sign(mintKeypair);

console.log("base64 serialized tx:", tx.serialize().toString("base64"));
```


### Code Style

This is my first contribution to SolanaKT and generally I tried to follow the existing style as much as I could, but took a bit of my own freedom in the unit test I added. Happy to adjust styles if needed!