### PR TITLE
Pass correct response type to getConfirmedSignaturesForAddress2 request

### DIFF
--- a/solana/src/main/java/com/solana/api/getConfirmedSignaturesForAddress2.kt
+++ b/solana/src/main/java/com/solana/api/getConfirmedSignaturesForAddress2.kt
@@ -3,6 +3,7 @@ package com.solana.api
 import com.solana.core.PublicKey
 import com.solana.models.ConfirmedSignFAddr2
 import com.solana.models.SignatureInformation
+import com.squareup.moshi.Types
 
 fun Api.getConfirmedSignaturesForAddress2(
     account: PublicKey,
@@ -17,7 +18,7 @@ fun Api.getConfirmedSignaturesForAddress2(
 
     router.request<List<SignatureInformation>>(
         "getConfirmedSignaturesForAddress2", params,
-        List::class.java
+        Types.newParameterizedType(List::class.java, SignatureInformation::class.java)
     ) { result ->
         result.onSuccess {
             onComplete(Result.success(it))


### PR DESCRIPTION
## Description
- When trying to use a response of `getConfirmedSignaturesForAddress2` request for the address it throws `java.lang.ClassCastException: com.squareup.moshi.LinkedHashTreeMap cannot be cast to com.solana.models.SignatureInformation`

## Work Completed
- Pass `Types.newParameterizedType(List::class.java, SignatureInformation::class.java)` to router.request method, to define the type of elements of the list

## Testing
- Tested in the sample app