### PR TITLE
update readme to reflect new repo location

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ repositories {
 	...
 	maven {
        name = "GitHubPackages"
-       url = "https://maven.pkg.github.com/ajamaica/SolanaKT"
+       url = "https://maven.pkg.github.com/metaplex-foundation/SolanaKT"
        credentials {
 		   username = "<YOUR_GITHUB_USERNAME>"
 		   password = "<YOUR_GITHUB_TOKENS>"


### PR DESCRIPTION
## Description

Followed the instructions in the README to use `ajamaica/SolanaKT` but my gradle wasn't picking it up. I just had to update it to use `metaplex-foundation/SolanaKT` to find the new location of the Github Package.

## Work Completed

Updated the readme

## API Changes
n/a

## Testing

I ran it myself with the new instructions to depend on it correctly