### PR TITLE
added change parameter to bip44WithChange private key generator

### DIFF
--- a/solana/src/main/java/com/solana/vendor/bip32/wallet/SolanaBip44.kt
+++ b/solana/src/main/java/com/solana/vendor/bip32/wallet/SolanaBip44.kt
@@ -18,15 +18,15 @@ class SolanaBip44 {
      * @param derivableType bip44 derivableType
      * @return PrivateKey
      */
-    fun getPrivateKeyFromSeed(seed: ByteArray, derivableType: DerivableType?): ByteArray {
+    fun getPrivateKeyFromSeed(seed: ByteArray, derivableType: DerivableType?, change: Int = CHANGE): ByteArray {
         return when (derivableType) {
             DerivableType.BIP44 -> getPrivateKeyFromBip44Seed(seed)
-            DerivableType.BIP44CHANGE -> getPrivateKeyFromBip44SeedWithChange(seed)
+            DerivableType.BIP44CHANGE -> getPrivateKeyFromBip44SeedWithChange(seed, change)
             else -> throw RuntimeException("DerivableType not supported")
         }
     }
 
-    private fun getPrivateKeyFromBip44SeedWithChange(seed: ByteArray): ByteArray {
+    private fun getPrivateKeyFromBip44SeedWithChange(seed: ByteArray, change: Int): ByteArray {
         val masterAddress = hdKeyGenerator.getAddressFromSeed(seed, solanaCoin)
         val purposeAddress =
             hdKeyGenerator.getAddress(masterAddress, PURPOSE, solanaCoin.alwaysHardened) // 44H
@@ -36,9 +36,9 @@ class SolanaBip44 {
             hdKeyGenerator.getAddress(coinTypeAddress, ACCOUNT, solanaCoin.alwaysHardened) //0H
         val changeAddress = hdKeyGenerator.getAddress(
             accountAddress,
-            CHANGE.toLong(),
+            change.toLong(),
             solanaCoin.alwaysHardened
-        ) //0H
+        )
         return changeAddress.privateKey.privateKey
     }
 


### PR DESCRIPTION
## Description
- closes https://github.com/metaplex-foundation/SolanaKT/issues/116

## Work Completed
- added a parameter to getPrivateKeyFromSeed to allow consumers to use Bip44 with change

## API Changes
- added a parameter to getPrivateKeyFromSeed, but provided default value so non-breaking