### PR TITLE
Change rentEpoch to ULong

### DIFF
--- a/solana/src/main/java/com/solana/api/getAccountInfo.kt
+++ b/solana/src/main/java/com/solana/api/getAccountInfo.kt
@@ -42,7 +42,7 @@ class AccountRequest(
 
 @Serializable
 data class AccountInfo<D>(val data: D?, val executable: Boolean,
-                          val lamports: Long, val owner: String?, val rentEpoch: Long)
+                          val lamports: Long, val owner: String?, val rentEpoch: ULong)
 
 fun <A> SolanaAccountSerializer(serializer: KSerializer<A>) =
     AccountInfoSerializer(


### PR DESCRIPTION
## Description
- We had problem of rent epoch (18446744073709551615) being higher than Long (9223372036854775807) 


## Work Completed
- changing the type from Long to ULong made it work. idk if this should be done to the lamports field as well.


## API Changes
- Long to ULong

## Testing
- Testing were done on our Shaga build.